### PR TITLE
Revert "fix(deps): bump @auth0/auth0-spa-js from 1.15.0 to 1.16.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,9 +54,9 @@
       }
     },
     "node_modules/@auth0/auth0-spa-js": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.16.0.tgz",
-      "integrity": "sha512-vGeUQZJfNwqEd/OxrNpgPVRWCuPUbCXT1OBdWTxoyampPSkcjf0JOQzLng+BOjCO2OihN4dGNWLZ5wvOQMIrmA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.15.0.tgz",
+      "integrity": "sha512-d/crchAbhncl9irIMuw1zNSZgX+id0U7mzASQr2htMJ73JCYaAvBSdGXL0WcYS4yBm1Xsx1JYm3b5tEZ5p/ncg==",
       "dependencies": {
         "abortcontroller-polyfill": "^1.7.1",
         "browser-tabs-lock": "^1.2.13",
@@ -30153,9 +30153,9 @@
   },
   "dependencies": {
     "@auth0/auth0-spa-js": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.16.0.tgz",
-      "integrity": "sha512-vGeUQZJfNwqEd/OxrNpgPVRWCuPUbCXT1OBdWTxoyampPSkcjf0JOQzLng+BOjCO2OihN4dGNWLZ5wvOQMIrmA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.15.0.tgz",
+      "integrity": "sha512-d/crchAbhncl9irIMuw1zNSZgX+id0U7mzASQr2htMJ73JCYaAvBSdGXL0WcYS4yBm1Xsx1JYm3b5tEZ5p/ncg==",
       "requires": {
         "abortcontroller-polyfill": "^1.7.1",
         "browser-tabs-lock": "^1.2.13",


### PR DESCRIPTION
Reverts jnt0r/vue-auth0-plugin#67

Reverting in order to test new merge strategy with automerging dependency updates