### PR TITLE
chore(build): set preventAssignment to true

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -141,6 +141,7 @@ function createReplacePlugin (
     isNodeBuild,
 ) {
     const replacements = {
+        preventAssignment: true,
         __COMMIT__: `"${process.env.COMMIT}"`,
         __VERSION__: `"${pkg.version}"`,
         __DEV__: isBundlerESMBuild


### PR DESCRIPTION
Removes warning in rollup build:  'preventAssignment' currently defaults to false. It is recommended to set this option to true, as the next major version will default this option to true.