### PR TITLE
Remove state from url after redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea/
 /dist/
 /coverage/
+/vue-auth0-plugin-0.0.0-semantically-released.tgz

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -76,6 +76,10 @@ async function initialize (app: App, authClient: Auth0Client): Promise<void> {
             // handle the redirect and retrieve tokens
             const { appState } = await client.handleRedirectCallback();
 
+            window.history.replaceState(
+                { ...window.history.state, code: undefined, state: undefined },
+                document.title, window.location.pathname);
+
             // Notify subscribers that the redirect callback has happened, passing the appState
             // (useful for retrieving any pre-authentication state)
             app.config.globalProperties.$router.push(appState && appState.targetUrl ? appState.targetUrl : '/');

--- a/test/plugin.spec.ts
+++ b/test/plugin.spec.ts
@@ -98,6 +98,18 @@ describe('initialize', () => {
             expect(Plugin.properties.client).toEqual(client);
         });
     });
+
+    it('should remove code and state properties from historystate', async () => {
+        window.history.pushState(
+            { someOtherProperty: 'ShouldStayInState', code: 'SomeCode', state: 'SomeState' }, '', '');
+
+        expect(window.history.state).toEqual(
+            { someOtherProperty: 'ShouldStayInState', code: 'SomeCode', state: 'SomeState' });
+
+        return Plugin.initialize(app, instance(client)).then(() => {
+            expect(window.history.state).toEqual({ someOtherProperty: 'ShouldStayInState' });
+        });
+    });
 });
 
 describe('methods should be delegated', () => {


### PR DESCRIPTION
When using vue-router with WebHashHistory mode the state parameters code and state in the URL were not removed. #121