### PR TITLE
Export authentication state

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ Or in a component
 </template>
 ```
 
+If you want to use the state of authentication when you do not have access to the Vue instance, you can use the exported AuthenticationState.
+
+```js
+import { AuthenticationState } from 'vue-auth0-plugin';
+
+if (!AuthenticationState.authenticated) {
+    // do something here
+}
+```
+
 ## AuthenticationGuard
 
 The plugin implements a Vue Router NavigationGuard to secure routes with Auth0. The example below shows how to use this AuthenticationGuard.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,29 @@ Or in a component
     <button v-on:click="$auth.logout()">Logout</button>
   </div>
 </template>
+```
 
+## AuthenticationGuard
+
+The plugin implements a Vue Router NavigationGuard to secure routes with Auth0. The example below shows how to use this AuthenticationGuard.
+
+```js
+import { AuthenticationGuard } from 'vue-auth0-plugin';
+
+let routes = [
+    ...
+    {
+        path: '/private',
+        name: 'PrivateRoute',
+        component: () => import(/* webpackChunkName: "private" */ '../views/Private.vue'),
+        beforeEnter: AuthenticationGuard,
+    },
+];
+
+const router = createRouter({
+  history: createWebHistory(YOUR_BASE_URL),
+  routes,
+});
 ```
 
 ## Changelog

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,5 @@ export default {
     },
 };
 
-export { AuthenticationGuard };
+const AuthenticationState = Plugin.state;
+export { AuthenticationGuard, AuthenticationState };

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,7 +1,8 @@
-import VueAuth0Plugin from '../src';
+import VueAuth0Plugin, { AuthenticationState } from '../src';
 import { createApp } from 'vue';
 import { mount } from '@vue/test-utils';
 import '../src/vue.d';
+import Plugin from '../src/plugin';
 
 describe('VueAuth0Plugin', () => {
     it('should be vue plugin', () => {
@@ -41,5 +42,13 @@ describe('VueAuth0Plugin', () => {
             loginWithPopup: expect.any(Function),
             logout: expect.any(Function),
         });
+    });
+
+    it('should export AuthenticationState', () => {
+        expect(AuthenticationState).toEqual(Plugin.state);
+        Plugin.state.loading = true;
+        Plugin.state.authenticated = true;
+        Plugin.state.user = { name: 'TestUser' };
+        expect(AuthenticationState).toEqual(Plugin.state);
     });
 });


### PR DESCRIPTION
Exports the state of the plugin as AuthenticationState so it can be used when not having access to the Vue instance. For example in Vou Router beforeEnter method. 

Proposed in #139 