### PR TITLE
Enhance guards and asyncability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
+    branches: [ master, beta ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, beta ]
 
 jobs:
   build_and_test:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,14 @@ import { AuthenticationState } from 'vue-auth0-plugin';
 if (!AuthenticationState.authenticated) {
     // do something here
 }
+
+// or asynchronous using Promise
+if (!await AuthenticationState.getAuthenticatedAsPromise) {
+    // do something here
+}
 ```
+
+> **INFO**: The synchronous `AuthenticationState.authenticated` can give wrong result if used before initialization of the plugin. Then the plugin is still loading the state of authentication and returns the default value _false_. In this case you should use the asynchronous `AuthenticationState.getAuthenticatedAsPromise` that resolves when the loading has finished and then returns the state of authentication.
 
 If you want to use the properties provided by Auth0 when you do not have access to the Vue instance, you can use the exported AuthenticationProperties.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ if (!auth.authenticated) {
 }
 ```
 
-Auth0 can also be injected as ´auth´ using the Options API like the example below
+Auth0 can also be injected using the Options API like the example below
 
 ```html
 <template>
@@ -96,12 +96,14 @@ import { AuthenticationProperties as auth0 } from 'vue-auth0-plugin';
 const token = auth0.getTokenSilently();
 ```
 
-## AuthenticationGuard
+## AuthenticationGuards
 
-The plugin implements a Vue Router NavigationGuard to secure routes with Auth0. The example below shows how to use this AuthenticationGuard.
+The plugin implements two Vue Router NavigationGuards to secure routes with Auth0. The `AuthenticationGuard` has an integrated redirect to the Auth0 login when the user is not authenticated. The `AuthenticationGuardWithoutLoginRedirect` does not have this redirect. The example below shows how to use this AuthenticationGuards.
 
 ```js
 import { AuthenticationGuard } from 'vue-auth0-plugin';
+// or alternative
+import { AuthenticationGuardWithoutLoginRedirect } from 'vue-auth0-plugin';
 
 let routes = [
     ...
@@ -109,7 +111,7 @@ let routes = [
         path: '/private',
         name: 'PrivateRoute',
         component: () => import(/* webpackChunkName: "private" */ '../views/Private.vue'),
-        beforeEnter: AuthenticationGuard,
+        beforeEnter: AuthenticationGuard, // or AuthenticationGuardWithoutLoginRedirect
     },
 ];
 

--- a/samples/simple-vue3-sample/src/main.js
+++ b/samples/simple-vue3-sample/src/main.js
@@ -10,4 +10,4 @@ app.use(VueAuth0Plugin, {
     client_id: process.env.VUE_APP_AUTH0_CLIENT_ID,
     redirect_uri: 'https://192.168.178.106:8080',
 });
-app.mount('#app')
+app.mount('#app');

--- a/src/AuthProperty.ts
+++ b/src/AuthProperty.ts
@@ -13,6 +13,7 @@ import {
 
 export default interface AuthProperty {
     authenticated: boolean;
+    getAuthenticatedAsPromise: () => Promise<boolean>;
     loading: boolean;
     user?: User;
     client?: Auth0Client,

--- a/src/guards/AbstractAuthenticationGuard.ts
+++ b/src/guards/AbstractAuthenticationGuard.ts
@@ -1,17 +1,20 @@
 import { RouteLocationNormalized } from 'vue-router';
-import Plugin from './plugin';
+import Plugin from '../plugin';
 import { watch } from 'vue';
 
 export default async (
     to: RouteLocationNormalized,
     from: RouteLocationNormalized,
+    autoLogin: boolean,
 ): Promise<boolean> => {
     // define verify method for later use
     const verify = async () => {
         if (Plugin.state.authenticated) {
             return true;
         }
-        await Plugin.properties.loginWithRedirect({ appState: { targetUrl: to.fullPath } });
+        if (autoLogin) {
+            await Plugin.properties.loginWithRedirect({ appState: { targetUrl: to.fullPath } });
+        }
         return false;
     };
 

--- a/src/guards/AuthenticationGuardWithLoginRedirect.ts
+++ b/src/guards/AuthenticationGuardWithLoginRedirect.ts
@@ -1,0 +1,9 @@
+import { RouteLocationNormalized } from 'vue-router';
+import AbstractAuthenticationGuard from './AbstractAuthenticationGuard';
+
+export default async (
+    to: RouteLocationNormalized,
+    from: RouteLocationNormalized,
+): Promise<boolean> => {
+    return AbstractAuthenticationGuard(to, from, true);
+};

--- a/src/guards/AuthenticationGuardWithoutLoginRedirect.ts
+++ b/src/guards/AuthenticationGuardWithoutLoginRedirect.ts
@@ -1,0 +1,9 @@
+import { RouteLocationNormalized } from 'vue-router';
+import AbstractAuthenticationGuard from './AbstractAuthenticationGuard';
+
+export default async (
+    to: RouteLocationNormalized,
+    from: RouteLocationNormalized,
+): Promise<boolean> => {
+    return AbstractAuthenticationGuard(to, from, false);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import Plugin from './plugin';
 import AuthenticationGuard from './AuthenticationGuard';
 import AuthProperty from './AuthProperty';
 
-const vueAuthInjectionKey = 'auth'
+const vueAuthInjectionKey = 'auth';
 
 export default {
     install (app: App, options: Auth0ClientOptions): void {
@@ -16,8 +16,14 @@ export default {
     },
 };
 
-const injectAuth = () => inject<AuthProperty>(vueAuthInjectionKey)
+const injectAuth = () => inject<AuthProperty>(vueAuthInjectionKey);
 
 const AuthenticationState = Plugin.state;
 const AuthenticationProperties = Plugin.properties;
-export { AuthenticationGuard, AuthenticationState, AuthenticationProperties, injectAuth, vueAuthInjectionKey as injectionKey };
+export {
+    AuthenticationGuard,
+    AuthenticationState,
+    AuthenticationProperties,
+    injectAuth,
+    vueAuthInjectionKey as injectionKey,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import { App, inject } from 'vue';
 import createAuth0Client, { Auth0ClientOptions } from '@auth0/auth0-spa-js';
 import Plugin from './plugin';
-import AuthenticationGuard from './AuthenticationGuard';
 import AuthProperty from './AuthProperty';
+import AuthenticationGuardWithoutLoginRedirect from './guards/AuthenticationGuardWithoutLoginRedirect';
+import AuthenticationGuardWithLoginRedirect from './guards/AuthenticationGuardWithLoginRedirect';
 
 const vueAuthInjectionKey = 'auth';
 
@@ -21,7 +22,8 @@ const injectAuth = () => inject<AuthProperty>(vueAuthInjectionKey);
 const AuthenticationState = Plugin.state;
 const AuthenticationProperties = Plugin.properties;
 export {
-    AuthenticationGuard,
+    AuthenticationGuardWithLoginRedirect as AuthenticationGuard,
+    AuthenticationGuardWithoutLoginRedirect,
     AuthenticationState,
     AuthenticationProperties,
     injectAuth,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import { App, reactive } from 'vue';
+import { App, reactive, watch } from 'vue';
 import {
     Auth0Client,
     GetIdTokenClaimsOptions,
@@ -16,12 +16,21 @@ import AuthProperty from './AuthProperty';
 const state = reactive({
     loading: true,
     authenticated: false,
+    getAuthenticatedAsPromise: () => new Promise<boolean>((resolve) => {
+        const unwatch = watch(() => state.loading, async () => {
+            if (!state.loading) {
+                unwatch();
+                resolve(state.authenticated);
+            }
+        });
+    }),
     user: undefined,
     popupOpen: false,
     error: undefined,
 } as {
     loading: boolean,
     authenticated: boolean,
+    getAuthenticatedAsPromise: () => Promise<boolean>,
     user?: User,
     popupOpen: boolean,
     error?: string
@@ -29,6 +38,7 @@ const state = reactive({
 
 const properties = reactive({
     authenticated: false,
+    getAuthenticatedAsPromise: state.getAuthenticatedAsPromise,
     loading: true,
     user: undefined,
     client: undefined,

--- a/test/AuthenticationGuardWithoutLoginRedirect.spec.ts
+++ b/test/AuthenticationGuardWithoutLoginRedirect.spec.ts
@@ -1,10 +1,10 @@
 import { RouteLocationNormalized } from 'vue-router';
 import { instance, mock, when } from 'ts-mockito';
 import authPlugin from '../src/plugin';
-import AuthenticationGuard from '../src/guards/AuthenticationGuardWithLoginRedirect';
+import AuthenticationGuardWithoutLoginRedirect from '../src/guards/AuthenticationGuardWithoutLoginRedirect';
 
-describe('AuthenticationGuard', () => {
-    it('should call loginWithRedirect when not authenticated', async () => {
+describe('AuthenticationGuardWithoutLoginRedirect', () => {
+    it('should not call loginWithRedirect when not authenticated', async () => {
         const to: RouteLocationNormalized = mock();
         const from: RouteLocationNormalized = mock();
         when(to.fullPath).thenReturn('/targetRoute');
@@ -12,12 +12,10 @@ describe('AuthenticationGuard', () => {
         authPlugin.state.loading = false;
         authPlugin.properties.loginWithRedirect = jest.fn();
 
-        const returnValue = await AuthenticationGuard(instance(to), instance(from));
+        const returnValue = await AuthenticationGuardWithoutLoginRedirect(instance(to), instance(from));
 
         expect(returnValue).toBeFalsy();
-        return expect(authPlugin.properties.loginWithRedirect).toBeCalledWith(expect.objectContaining({
-            appState: { targetUrl: '/targetRoute' },
-        }));
+        return expect(authPlugin.properties.loginWithRedirect).not.toBeCalled();
     });
 
     it('should return true when authenticated and not loading', async () => {
@@ -27,7 +25,7 @@ describe('AuthenticationGuard', () => {
         authPlugin.state.authenticated = true;
         authPlugin.state.loading = false;
 
-        return expect(AuthenticationGuard(instance(to), instance(from))).resolves.toBeTruthy();
+        return expect(AuthenticationGuardWithoutLoginRedirect(instance(to), instance(from))).resolves.toBeTruthy();
     });
 
     it('should return true when finished loading', async () => {
@@ -39,7 +37,7 @@ describe('AuthenticationGuard', () => {
 
         let resolved = false;
         let returnValue;
-        AuthenticationGuard(instance(to), instance(from))
+        AuthenticationGuardWithoutLoginRedirect(instance(to), instance(from))
             .then((value) => {
                 resolved = true;
                 returnValue = value;
@@ -55,7 +53,7 @@ describe('AuthenticationGuard', () => {
         expect(returnValue).toBeTruthy();
     });
 
-    it('should call loginWithRedirect when finished loading', async () => {
+    it('should not call loginWithRedirect when finished loading', async () => {
         const to: RouteLocationNormalized = mock();
         when(to.fullPath).thenReturn('/targetRoute');
         const from: RouteLocationNormalized = mock();
@@ -63,7 +61,7 @@ describe('AuthenticationGuard', () => {
         authPlugin.state.authenticated = false;
         authPlugin.state.loading = true;
 
-        AuthenticationGuard(instance(to), instance(from));
+        AuthenticationGuardWithoutLoginRedirect(instance(to), instance(from));
 
         expect(authPlugin.properties.loginWithRedirect).not.toBeCalled();
 
@@ -72,8 +70,6 @@ describe('AuthenticationGuard', () => {
         // Needs small delay because of watchEffect.
         await new Promise((resolve) => setTimeout(resolve, 500));
 
-        return expect(authPlugin.properties.loginWithRedirect).toBeCalledWith(expect.objectContaining({
-            appState: { targetUrl: '/targetRoute' },
-        }));
+        return expect(authPlugin.properties.loginWithRedirect).not.toBeCalled();
     });
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -32,6 +32,7 @@ describe('VueAuth0Plugin', () => {
 
         expect(wrapper.vm.$auth).toMatchObject({
             authenticated: expect.any(Boolean),
+            getAuthenticatedAsPromise: expect.any(Function),
             loading: expect.any(Boolean),
             user: undefined,
             client: undefined,
@@ -59,6 +60,7 @@ describe('VueAuth0Plugin', () => {
         // @ts-ignore
         expect(wrapper.vm.auth).toMatchObject({
             authenticated: expect.any(Boolean),
+            getAuthenticatedAsPromise: expect.any(Function),
             loading: expect.any(Boolean),
             user: undefined,
             client: undefined,
@@ -74,9 +76,11 @@ describe('VueAuth0Plugin', () => {
 
     it('should export AuthenticationState', () => {
         expect(AuthenticationState).toEqual(Plugin.state);
+
         Plugin.state.loading = true;
         Plugin.state.authenticated = true;
         Plugin.state.user = { name: 'TestUser' };
+
         expect(AuthenticationState).toEqual(Plugin.state);
     });
 });

--- a/test/plugin.spec.ts
+++ b/test/plugin.spec.ts
@@ -2,6 +2,7 @@ import { deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import createAuth0Client, { Auth0Client, User } from '@auth0/auth0-spa-js';
 import Plugin from '../src/plugin';
 import { createApp } from 'vue';
+import { AuthenticationState } from '../src';
 
 /* eslint-disable */
 /** Workaround for ts-mockito Bug **/
@@ -185,11 +186,31 @@ describe('methods should be delegated', () => {
 });
 
 describe('properties should be reactive', () => {
-    it('isAuthenticated should be reactive ', () => {
+    it('authenticated should be reactive ', () => {
         Plugin.state.authenticated = false;
         expect(Plugin.properties.authenticated).toBeFalsy();
 
         Plugin.state.authenticated = true;
         expect(Plugin.properties.authenticated).toBeTruthy();
+    });
+});
+
+describe('getAuthenticatedAsPromise', () => {
+    it('should resolve to false when not authenticated', async function () {
+        Plugin.state.loading = true;
+        Plugin.state.authenticated = false;
+        const authenticatedAsPromise = AuthenticationState.getAuthenticatedAsPromise();
+        Plugin.state.loading = false;
+        await expect(authenticatedAsPromise)
+            .resolves.toBeFalsy();
+    });
+
+    it('should resolve to true when authenticated', async function () {
+        Plugin.state.loading = true;
+        Plugin.state.authenticated = true;
+        const authenticatedAsPromise = AuthenticationState.getAuthenticatedAsPromise();
+        Plugin.state.loading = false;
+        await expect(authenticatedAsPromise)
+            .resolves.toBeTruthy();
     });
 });


### PR DESCRIPTION
Added new AuthenticationGuard (AuthenticationGuardWithoutLoginRedirect) that does not redirect the user if not authenticated.

Also added new function (getAuthenticatedAsPromise) to AuthenticationState to asynchronously get the value of authenticated property (in router setup for example)