### PR TITLE
fix: Only initialize plugin if redirecting from Auth0 to support mult…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export default {
         app.provide(vueAuthInjectionKey, Plugin.properties);
 
         const client = new Auth0Client(options);
-        Plugin.initialize(app, client);
+        Plugin.initialize(app, client, options.authorizationParams?.redirect_uri);
     },
 };
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -80,14 +80,15 @@ Object.defineProperties(properties, {
 
 let client: Auth0Client;
 
-async function initialize (app: App, authClient: Auth0Client): Promise<void> {
+async function initialize (app: App, authClient: Auth0Client, redirectUri?: string): Promise<void> {
     client = authClient;
 
     // set client property to created Auth0Client instance
     properties.client = client;
 
     // If the user is returning to the app after authentication
-    if (window.location.search.includes('state=') || window.location.search.includes('code=')) {
+    if ((redirectUri === undefined || window.location.href.split('?')[0] === redirectUri) &&
+        (window.location.search.includes('state=') || window.location.search.includes('code='))) {
         let appState;
         try {
             // handle the redirect and retrieve tokens

--- a/test/plugin.spec.ts
+++ b/test/plugin.spec.ts
@@ -191,6 +191,37 @@ describe('initialize', () => {
         });
     });
 
+    test('should not redirect if redirectUri is different than current url', (done) => {
+        const clientInstance = instance(client);
+        setQueryValue('?code=code123&state=state456');
+        when(client.handleRedirectCallback()).thenResolve({ appState: { targetUrl: '/testUrl' } });
+        const replaceFn = jest.fn();
+        window.location.replace = replaceFn;
+
+        Plugin.initialize(app, clientInstance, 'http://localhost:1234/some/random/path').then(() => {
+            verify(client.handleRedirectCallback()).never();
+
+            expect(replaceFn).not.toHaveBeenCalled();
+            done();
+        });
+    });
+
+    test('should redirect if redirectUri matches current url', (done) => {
+        const clientInstance = instance(client);
+        setQueryValue('?code=code123&state=state456');
+        when(client.handleRedirectCallback()).thenResolve({ appState: { targetUrl: '/testUrl' } });
+        const replaceFn = jest.fn();
+        window.location.replace = replaceFn;
+        window.location.href = 'http://localhost:1234/some/random/path?code=code123&state=state456';
+
+        Plugin.initialize(app, clientInstance, 'http://localhost:1234/some/random/path').then(() => {
+            verify(client.handleRedirectCallback()).called();
+
+            expect(replaceFn).toHaveBeenCalledWith('/testUrl');
+            done();
+        });
+    });
+
     it('should expose initialised Auth0Client as client property', async () => {
         const client = new Auth0Client({ clientId: '', domain: '' });
 


### PR DESCRIPTION
…iple authentication methods in an application

This ensures that the plugin is only being initialized if being redirected to the defined redirectUri of the auth0 client.

fixes #874